### PR TITLE
user_class should be a string if possible to avoid a Rails deprecation warning

### DIFF
--- a/lib/generators/templates/tokenable.rb.erb
+++ b/lib/generators/templates/tokenable.rb.erb
@@ -4,7 +4,7 @@
 Tokenable::Config.lifespan = 7.days
 
 # The class in which your User resides.
-Tokenable::Config.user_class = <%= name %>
+Tokenable::Config.user_class = '<%= name %>'
 
 # The secret used to create these tokens. This is then used to verify the
 # token is valid. Note: Tokens are not encrypted, and container the user_id.

--- a/lib/tokenable/config.rb
+++ b/lib/tokenable/config.rb
@@ -13,7 +13,12 @@ module Tokenable
     mattr_writer :secret, default: -> { Rails.application.secret_key_base }
 
     # The user model that we will perform actions on
-    mattr_writer :user_class, default: -> { User }
+    mattr_writer :user_class, default: -> { 'User' }
+
+    def self.user_class
+      class_name = proc_reader(:user_class)
+      class_name.is_a?(String) ? class_name.constantize : class_name
+    end
 
     # We do this, as some of our defaults need to live in a Proc (as this library is loaded before Rails)
     # This means we can return the value when the method is called, instead of the Proc.

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -13,7 +13,7 @@ describe Tokenable::Generators::InstallGenerator, type: :generator do
       run_generator %w[SomeUser --strategy=devise]
 
       assert_file 'config/initializers/tokenable.rb' do |content|
-        assert_match(/Tokenable::Config.user_class = SomeUser/, content)
+        assert_match(/Tokenable::Config.user_class = 'SomeUser'/, content)
         assert_match(/Tokenable::Config.lifespan = 7.days/, content)
         assert_match(/Tokenable::Config.secret = Rails.application.secret_key_base/, content)
       end

--- a/spec/tokenable/config_spec.rb
+++ b/spec/tokenable/config_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 describe Tokenable::Config do
   it 'has the default values' do
+    expect(described_class.user_class).to eq(User)
     expect(described_class.secret).not_to eq(nil)
     expect(described_class.secret).to eq(Rails.application.secret_key_base)
     expect(described_class.lifespan).to eq(7.days)
@@ -23,5 +24,12 @@ describe Tokenable::Config do
 
     expect { described_class.not_a_thing }.to raise_error(NoMethodError)
     expect(described_class.respond_to?(:not_a_thing)).to eq(false)
+  end
+
+  it 'ensures user_class returns a class, when a string is defined' do
+    described_class.user_class = 'User'
+
+    expect(described_class.class_variable_get('@@user_class')).to be_a(String)
+    expect(described_class.user_class).to eq(User)
   end
 end


### PR DESCRIPTION
Closes #22